### PR TITLE
Enforce http2, fix dfx local server not supported by ic-rosetta-api

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -413,7 +413,9 @@ async fn forward_api(
 ) -> Result<Response<Body>, Box<dyn Error>> {
     let proxied_request = create_proxied_request(ip_addr, replica_url, request)?;
 
-    let client = Client::builder().build(hyper_tls::HttpsConnector::new());
+    let client = Client::builder()
+        .http2_only(true)
+        .build(hyper_tls::HttpsConnector::new());
     let response = client.request(proxied_request).await?;
     Ok(response)
 }
@@ -555,7 +557,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .enable_all()
         .build()?;
     runtime.block_on(async {
-        let server = Server::bind(&opts.address).serve(service);
+        let server = Server::bind(&opts.address).http2_only(true).serve(service);
         server.await?;
         Ok(())
     })


### PR DESCRIPTION
When `dfx` starts a local replica, it automatically starts `icx-proxy` to reroute the incoming requests. It uses `hyper` for http logic, and `hyper` doesn't properly support http1/http2 dual stack. The main `ic` repo assumes http2 in a lot of places, one consequence of that is `ic-rosetta-api` being unable to connect to the local replica started by `dfx`. This patch fixes that problem.

See ticket https://dfinity.atlassian.net/browse/ROSETTA1-162 for more context.