### PR TITLE
chore: Update rust version to 1.55.0 used for the mac release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             name: macos
             binary_path: target/release
             binary_files: icx-proxy
-            rust: 1.52.1
+            rust: 1.55.0
     steps:
     - uses: actions/checkout@master
 


### PR DESCRIPTION
This should fix the release build for Mac OS X.