### PR TITLE
feat: add linux-gnu release for use in sdk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         RUSTFLAGS: --remap-path-prefix=${GITHUB_WORKSPACE}=/builds/dfinity
       run: |
         cargo build --locked --release --target x86_64-unknown-linux-gnu
-        cd target/release
+        cd ${{ matrix.binary_path }} 
         ldd icx-proxy
       if: contains(matrix.target, 'linux-gnu')
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ '1.55.0' ]
-        os: [ ubuntu-latest, macos-latest ]
+        target: [ x86_64-apple-darwin, x86_64-unknown-linux-musl, x86_64-unknown-linux-gnu ]
         include:
           - os: macos-latest
             target: x86_64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ericswanson/linux-binary-for-sdk
 
 jobs:
   build:
@@ -15,12 +16,17 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: macos-latest
+            target: x86_64-apple-darwin
             binary_path: target/release
             name: macos
           - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
             binary_path: target/x86_64-unknown-linux-musl/release
             name: linux
-
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary_path: target/x86_64-unknown-linux-gnu/release
+            name: linux-gnu
     steps:
     - uses: actions/checkout@v2
 
@@ -38,12 +44,12 @@ jobs:
         override: true
       if: contains(matrix.os, 'macos')
 
-    - name: Linux hack
+    - name: Linux hack (musl only)
       run: |
           echo "1.58.1" >./rust-toolchain
-      if: contains(matrix.os, 'ubuntu')
+      if: contains(matrix.target, 'linux-musl')
 
-    - name: Linux build
+    - name: Linux build (musl)
       uses: dfinity/rust-musl-action@master
       with:
         args: |
@@ -51,7 +57,16 @@ jobs:
           echo "1.55.0" >./rust-toolchain
           rustup target add x86_64-unknown-linux-musl
           RUSTFLAGS="--remap-path-prefix=${GITHUB_WORKSPACE}=/builds/dfinity" cargo deb --target x86_64-unknown-linux-musl -- --locked
-      if: contains(matrix.os, 'ubuntu')
+      if: contains(matrix.target, 'linux-musl')
+
+    - name: Linux build (gnu)
+      env:
+        RUSTFLAGS: --remap-path-prefix=${GITHUB_WORKSPACE}=/builds/dfinity
+      run: |
+        cargo build --locked --release --target x86_64-unknown-linux-gnu
+        cd target/release
+        ldd icx-proxy
+      if: contains(matrix.target, 'linux-gnu')
 
     - name: macOS build
       env:
@@ -65,19 +80,19 @@ jobs:
     - name: Create tarball of binaries
       run: tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 
-    - name: Upload tarball
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: binaries.tar.gz
-        asset_name: binaries-${{ matrix.name }}.tar.gz
-        tag: ${{ env.SHA_SHORT }}
-
-    - name: Upload deb
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb
-        asset_name: icx-proxy.deb
-        tag: ${{ env.SHA_SHORT }}
-      if: contains(matrix.os, 'ubuntu')
+#    - name: Upload tarball
+#      uses: svenstaro/upload-release-action@v2
+#      with:
+#        repo_token: ${{ secrets.GITHUB_TOKEN }}
+#        file: binaries.tar.gz
+#        asset_name: binaries-${{ matrix.name }}.tar.gz
+#        tag: ${{ env.SHA_SHORT }}
+#
+#    - name: Upload deb
+#      uses: svenstaro/upload-release-action@v2
+#      with:
+#        repo_token: ${{ secrets.GITHUB_TOKEN }}
+#        file: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb
+#        asset_name: icx-proxy.deb
+#        tag: ${{ env.SHA_SHORT }}
+#      if: contains(matrix.target, 'linux-musl')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,19 +80,20 @@ jobs:
     - name: Create tarball of binaries
       run: tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 
-#    - name: Upload tarball
-#      uses: svenstaro/upload-release-action@v2
-#      with:
-#        repo_token: ${{ secrets.GITHUB_TOKEN }}
-#        file: binaries.tar.gz
-#        asset_name: binaries-${{ matrix.name }}.tar.gz
-#        tag: ${{ env.SHA_SHORT }}
-#
-#    - name: Upload deb
-#      uses: svenstaro/upload-release-action@v2
-#      with:
-#        repo_token: ${{ secrets.GITHUB_TOKEN }}
-#        file: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb
-#        asset_name: icx-proxy.deb
-#        tag: ${{ env.SHA_SHORT }}
-#      if: contains(matrix.target, 'linux-musl')
+    - name: Upload tarball
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: binaries.tar.gz
+        asset_name: binaries-${{ matrix.name }}.tar.gz
+        tag: ${{ env.SHA_SHORT }}
+
+    - name: Upload deb
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb
+        asset_name: icx-proxy.deb
+        tag: ${{ env.SHA_SHORT }}
+      if: contains(matrix.target, 'linux-musl')
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ericswanson/linux-binary-for-sdk
 
 jobs:
   build:


### PR DESCRIPTION
Add an x86_64-unknown-linux-gnu release binary tarball , which matches what we have been shipping with dfx.

Example output: https://github.com/ericswanson-dfinity/icx-proxy/releases/tag/ff0c4a1
