### PR TITLE
fix: mute candid warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "candid"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12970d8d0620d2bdb7e81a5b13ed11e41fcdfeba53d61e45b5853afcbf9611fd"
+checksum = "f5531982124b31420dc41d0c8c0abbdd03e97d561dfb2af027b9140ee2b1f50c"
 dependencies = [
  "anyhow",
  "binread",
@@ -755,6 +755,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64",
+ "candid",
  "clap",
  "garcon",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.34"
 base64 = "0.13"
+candid = { version = "0.7.11", features = ["mute_warnings"] }
 clap = { version = "3", features = ["cargo", "derive"] }
 garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.3"


### PR DESCRIPTION
This eliminates log spam from asset canister mismatches.