### PR TITLE
chore: release workflow: check contents of macos binary tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Create tarball of binaries
       run: |
         pwd
-        hexdump -C ${{ matrix.binary_path }}/icx-proxy | head
+        # hexdump -C ${{ matrix.binary_path }}/icx-proxy | head
         tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 
     - name: Inspect tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,13 +77,11 @@ jobs:
         otool -L icx-proxy
         ls -l
         hexdump -C icx-proxy | head
-        hexdump -C icx-proxy | head
       if: contains(matrix.os, 'macos')
 
     - name: Create tarball of binaries
       run: |
         pwd
-        # sleep 10
         hexdump -C ${{ matrix.binary_path }}/icx-proxy | head
         tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 
@@ -94,7 +92,6 @@ jobs:
         cat binaries.tar.gz | gunzip | tar -xv
         ls -l icx-proxy
         hexdump -C icx-proxy | head
-        ./icx-proxy --help
 
     - name: Upload tarball
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,8 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: deb-${{ matrix.name }}
-        path: icx-proxy.deb
+        path: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb
+        asset_name: icx-proxy.deb
       if: contains(matrix.target, 'linux-musl')
 
   upload:
@@ -148,8 +149,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb
-          asset_name: icx-proxy.deb
+          file: icx-proxy.deb
           tag: ${{ env.SHA_SHORT }}
         if: contains(matrix.target, 'linux-musl')
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
         cat binaries.tar.gz | gunzip | tar -xv
         ls -l icx-proxy
         hexdump -C icx-proxy | head
+        ./icx-proxy --help
 
     - name: Upload tarball
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,10 +80,15 @@ jobs:
       if: contains(matrix.os, 'macos')
 
     - name: Create tarball of binaries
-      run: tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
+      run: |
+        pwd
+        hexdump -C ${{ matrix.binary_path }}/icx-proxy | head
+        tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 
     - name: Inspect tarball
       run: |
+        pwd
+        ls -l
         cat binaries.tar.gz | gunzip | tar -xv
         ls -l icx-proxy
         hexdump -C icx-proxy | head

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,12 @@ jobs:
     - name: Create tarball of binaries
       run: tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 
+    - name: Inspect tarball
+      run: |
+        cat binaries.tar.gz | gunzip | tar -xv
+        ls -l icx-proxy
+        hexdump -C icx-proxy | head
+
     - name: Upload tarball
       uses: svenstaro/upload-release-action@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,9 @@ jobs:
 
     - name: Inspect input binary and tarball contents
       run: |
-        hexdump -C target/release/icx-proxy | head
-        hexdump -C target/release/icx-proxy | tail
-        target/release/icx-proxy --help
+        hexdump -C ${{ matrix.binary_path }}/icx-proxy | head
+        hexdump -C ${{ matrix.binary_path }}/icx-proxy | tail
+        ${{ matrix.binary_path }}/icx-proxy --help
         
         ARCHIVE="$(pwd)/binaries.tar.gz"
         cd "$(mktemp -d)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,11 +82,18 @@ jobs:
     - name: Create tarball of binaries
       run: |
         while true ; do
+          echo "target/release"
+          ls -l target/release
+          hexdump -C target/release/icx-proxy | head
+
           tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
+
+          echo "check tarball"
           rm -f icx-proxy
           cat binaries.tar.gz | gunzip | tar -xv
           ls -l icx-proxy
           hexdump -C icx-proxy | head
+          
           ./icx-proxy --help && exit 0
         done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,11 @@ jobs:
       run: |
         ARCHIVE="$(pwd)/binaries.tar.gz"
         cd "$(mktemp -d)"
-
+        tar --version
         tar -xzvf "$ARCHIVE"
         ls -l icx-proxy
         hexdump -C icx-proxy | head
+        hexdump -C icx-proxy | tail
         ./icx-proxy --help
 
     - name: Upload tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
         otool -L icx-proxy
         ls -l
         hexdump -C icx-proxy | head
+        hexdump -C icx-proxy | head
       if: contains(matrix.os, 'macos')
 
     - name: Create tarball of binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,12 @@ jobs:
     - name: Create tarball of binaries
       run: tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 
-    - name: Inspect tarball
+    - name: Inspect input binary and tarball contents
       run: |
+        hexdump -C target/release/icx-proxy | head
+        hexdump -C target/release/icx-proxy | tail
+        target/release/icx-proxy --help
+        
         ARCHIVE="$(pwd)/binaries.tar.gz"
         cd "$(mktemp -d)"
         tar --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - macos-binary
 
 jobs:
   build:
@@ -74,6 +75,8 @@ jobs:
         cargo build --locked --release
         cd target/release
         otool -L icx-proxy
+        ls -l
+        hexdump -C icx-proxy | head
       if: contains(matrix.os, 'macos')
 
     - name: Create tarball of binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Create tarball of binaries
       run: |
         pwd
-        sleep 10
+        # sleep 10
         # hexdump -C ${{ matrix.binary_path }}/icx-proxy | head
         tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
             name: linux-gnu
     steps:
+      - name: Setup environment variables
+        run: echo "SHA_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV
+
       - name: Download tarball artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
         name: tarball-${{ matrix.name }}
         path: binaries.tar.gz
     - name: Copy deb artifact
-      run: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb icx-proxy.deb
+      run: cp target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb icx-proxy.deb
       if: contains(matrix.target, 'linux-musl')
     - name: Upload deb artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,15 @@ jobs:
       if: contains(matrix.os, 'macos')
 
     - name: Create tarball of binaries
-      run: tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
+      run: |
+        while true ; do
+          tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
+          rm -f icx-proxy
+          cat binaries.tar.gz | gunzip | tar -xv
+          ls -l icx-proxy
+          hexdump -C icx-proxy | head
+          ./icx-proxy --help && exit 0
+        done
 
     - name: Inspect tarball
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - macos-binary
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - macos-binary
 
 jobs:
   build:
@@ -94,20 +95,61 @@ jobs:
         hexdump -C icx-proxy | tail
         ./icx-proxy --help
 
-    - name: Upload tarball
-      uses: svenstaro/upload-release-action@v2
+    - name: Upload tarball artifact
+      uses: actions/upload-artifact@v2
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: binaries.tar.gz
-        asset_name: binaries-${{ matrix.name }}.tar.gz
-        tag: ${{ env.SHA_SHORT }}
-
-    - name: Upload deb
-      uses: svenstaro/upload-release-action@v2
+        name: tarball-${{ matrix.name }}
+        path: binaries.tar.gz
+    - name: Upload deb artifact
+      uses: actions/upload-artifact@v2
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb
-        asset_name: icx-proxy.deb
-        tag: ${{ env.SHA_SHORT }}
+        name: deb-${{ matrix.name }}
+        path: icx-proxy.deb
       if: contains(matrix.target, 'linux-musl')
+
+  upload:
+    runs-on: ${{ matrix.os }}
+    needs: [ build ]
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ '1.55.0' ]
+        target: [ x86_64-apple-darwin, x86_64-unknown-linux-musl, x86_64-unknown-linux-gnu ]
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            name: macos
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            name: linux
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            name: linux-gnu
+    steps:
+      - name: Download tarball artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: tarball-${{ matrix.name }}
+      - name: Download deb artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: deb-${{ matrix.name }}
+        if: contains(matrix.target, 'linux-musl')
+
+      - name: Upload tarball
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: binaries.tar.gz
+          asset_name: binaries-${{ matrix.name }}.tar.gz
+          tag: ${{ env.SHA_SHORT }}
+
+      - name: Upload deb
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb
+          asset_name: icx-proxy.deb
+          tag: ${{ env.SHA_SHORT }}
+        if: contains(matrix.target, 'linux-musl')
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,13 @@ jobs:
 
     - name: Create tarball of binaries
       run: |
+        set -x
         while true ; do
           echo "target/release"
           ls -l target/release
           hexdump -C target/release/icx-proxy | head
+        
+          tar --version
 
           tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
     - name: Create tarball of binaries
       run: |
         pwd
+        sleep 10
         # hexdump -C ${{ matrix.binary_path }}/icx-proxy | head
         tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         
           tar --version
 
-          tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
+          tar -cC ${{ matrix.binary_path }} icx-proxy | gzip >binaries.tar.gz
 
           echo "check tarball"
           rm -f icx-proxy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,10 +80,7 @@ jobs:
       if: contains(matrix.os, 'macos')
 
     - name: Create tarball of binaries
-      run: |
-        pwd
-        hexdump -C ${{ matrix.binary_path }}/icx-proxy | head
-        tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
+      run: tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 
     - name: Inspect tarball
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,36 +75,17 @@ jobs:
         cargo build --locked --release
         cd target/release
         otool -L icx-proxy
-        ls -l
-        hexdump -C icx-proxy | head
       if: contains(matrix.os, 'macos')
 
     - name: Create tarball of binaries
-      run: |
-        set -x
-        while true ; do
-          echo "target/release"
-          ls -l target/release
-          hexdump -C target/release/icx-proxy | head
-        
-          tar --version
-
-          tar -cC ${{ matrix.binary_path }} icx-proxy | gzip >binaries.tar.gz
-
-          echo "check tarball"
-          rm -f icx-proxy
-          cat binaries.tar.gz | gunzip | tar -xv
-          ls -l icx-proxy
-          hexdump -C icx-proxy | head
-          
-          ./icx-proxy --help && exit 0
-        done
+      run: tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 
     - name: Inspect tarball
       run: |
-        pwd
-        ls -l
-        cat binaries.tar.gz | gunzip | tar -xv
+        ARCHIVE="$(pwd)/binaries.tar.gz"
+        cd "$(mktemp -d)"
+
+        tar -xzvf "$ARCHIVE"
         ls -l icx-proxy
         hexdump -C icx-proxy | head
         ./icx-proxy --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,12 +100,14 @@ jobs:
       with:
         name: tarball-${{ matrix.name }}
         path: binaries.tar.gz
+    - name: Copy deb artifact
+      run: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb icx-proxy.deb
+      if: contains(matrix.target, 'linux-musl')
     - name: Upload deb artifact
       uses: actions/upload-artifact@v2
       with:
         name: deb-${{ matrix.name }}
-        path: target/x86_64-unknown-linux-musl/debian/icx-proxy_${{ env.ICX_VERSION }}_amd64.deb
-        asset_name: icx-proxy.deb
+        path: icx-proxy.deb
       if: contains(matrix.target, 'linux-musl')
 
   upload:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
         cat binaries.tar.gz | gunzip | tar -xv
         ls -l icx-proxy
         hexdump -C icx-proxy | head
+        ./icx-proxy --help
 
     - name: Upload tarball
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,9 @@ jobs:
           name: deb-${{ matrix.name }}
         if: contains(matrix.target, 'linux-musl')
 
+      - name: Look at files
+        run: ls -l
+
       - name: Upload tarball
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
       run: |
         pwd
         # sleep 10
-        # hexdump -C ${{ matrix.binary_path }}/icx-proxy | head
+        hexdump -C ${{ matrix.binary_path }}/icx-proxy | head
         tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz icx-proxy
 
     - name: Inspect tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - macos-binary
 
 jobs:
   build:
@@ -141,9 +140,6 @@ jobs:
         with:
           name: deb-${{ matrix.name }}
         if: contains(matrix.target, 'linux-musl')
-
-      - name: Look at files
-        run: ls -l
 
       - name: Upload tarball
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Some of the macos release tarballs contain a corrupt executable, in which the first 0x800000 bytes are all zeros.

For example, the macos release binary for commit https://github.com/dfinity/icx-proxy/commit/59674697309548b7021d457d95c32057e7681bf6 is corrupt:

```
$ wget https://github.com/dfinity/icx-proxy/releases/download/5967469/binaries-macos.tar.gz
$ tar -xzf binaries-macos.tar.gz 
$ ./icx-proxy --help
zsh: exec format error: ./icx-proxy
$ hexdump -C icx-proxy | head
00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00800000  40 69 6e 00 01 00 00 00  62 00 00 00 00 00 00 00  |@in.....b.......|
00800010  74 01 00 00 09 00 00 00  c0 6a 6e 00 01 00 00 00  |t........jn.....|
00800020  0c 00 00 00 00 00 00 00  40 69 6e 00 01 00 00 00  |........@in.....|
00800030  62 00 00 00 00 00 00 00  ff 00 00 00 09 00 00 00  |b...............|
00800040  cc 6a 6e 00 01 00 00 00  0d 00 00 00 00 00 00 00  |.jn.............|
00800050  40 69 6e 00 01 00 00 00  62 00 00 00 00 00 00 00  |@in.....b.......|
00800060  0f 01 00 00 09 00 00 00  fe 6a 6e 00 01 00 00 00  |.........jn.....|
00800070  0e 00 00 00 00 00 00 00  40 69 6e 00 01 00 00 00  |........@in.....|
```


I have not found a way to ensure that the macos release tarball contains a valid binary.  I tried:
- Adding retry logic to the workflow
- Splitting up the tar step from the gzip step

This PR makes two changes:
- Verify that the binary in the tarball can execute, or fail the CI run.
- Create all release artifacts before uploading any of them.  An alternative would have been to upload whichever worked, which would then be overwritten on retry.

