### PR TITLE
fix: added body decoding before validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +424,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +775,7 @@ dependencies = [
  "base64",
  "candid",
  "clap",
+ "flate2",
  "garcon",
  "hex",
  "hyper",
@@ -973,6 +992,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
 
 [[package]]
 name = "mio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = "1.0.34"
 base64 = "0.13"
 candid = { version = "0.7.11", features = ["mute_warnings"] }
 clap = { version = "3", features = ["cargo", "derive"] }
+flate2 = "1.0.0"
 garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.3"
 hyper = { version = "0.14.13", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,8 @@ use std::{
         Arc, Mutex,
     },
 };
+use std::io::prelude::{Read};
+use flate2::read::{GzDecoder, DeflateDecoder};
 
 mod config;
 mod logging;
@@ -282,6 +284,7 @@ async fn forward_request(
 
     let mut certificate: Option<Result<Vec<u8>, ()>> = None;
     let mut tree: Option<Result<Vec<u8>, ()>> = None;
+    let mut encoding: Option<String> = None;
 
     let mut builder = Response::builder().status(StatusCode::from_u16(http_response.status_code)?);
     for HeaderField(name, value) in http_response.headers {
@@ -338,6 +341,9 @@ async fn forward_request(
                     }
                 }
             }
+        } else if name.eq_ignore_ascii_case("CONTENT-ENCODING") {
+            let enc = value.trim().to_string();
+            encoding = Some(enc);
         }
 
         builder = builder.header(&name, value);
@@ -348,6 +354,7 @@ async fn forward_request(
     } else {
         None
     };
+    let decoded_body = decode_body(&http_response.body, encoding);
     let is_streaming = http_response.streaming_strategy.is_some();
     let response = if let Some(streaming_strategy) = http_response.streaming_strategy {
         let (mut sender, body) = body::Body::channel();
@@ -407,7 +414,7 @@ async fn forward_request(
                 &canister_id,
                 &agent,
                 &uri,
-                &http_response.body,
+                &decoded_body,
                 logger.clone(),
             ) {
                 Ok(valid) => valid,
@@ -467,6 +474,25 @@ async fn forward_request(
     Ok(response)
 }
 
+fn decode_body(body: &[u8], encoding: Option<String>) -> Vec<u8> {
+    match encoding {
+        Some(enc) => match enc.as_str() {
+            "gzip" => {
+                let decoded: &mut Vec<u8> = &mut vec![]; 
+                GzDecoder::new(body).read_to_end(decoded).unwrap();
+                decoded.to_vec()
+            },
+            "deflate" => {
+                let decoded: &mut Vec<u8> = &mut vec![]; 
+                DeflateDecoder::new(body).read_to_end(decoded).unwrap();
+                decoded.to_vec()
+            },
+            _ => body.to_vec(),
+        },
+        _ => body.to_vec(),
+    }
+}
+
 fn validate_body(
     certificate: &[u8],
     tree: &[u8],
@@ -515,8 +541,11 @@ fn validate_body(
     }
 
     let path = ["http_assets".into(), uri.path().into()];
+    println!("START {}", uri.path());
     let tree_sha = match tree.lookup_path(&path) {
-        LookupResult::Found(v) => v,
+        LookupResult::Found(v) => {
+            v
+        },
         _ => match tree.lookup_path(&["http_assets".into(), "/index.html".into()]) {
             LookupResult::Found(v) => v,
             _ => {
@@ -532,9 +561,9 @@ fn validate_body(
 
     let mut sha256 = Sha256::new();
     sha256.update(response_body);
-    let body_sha = sha256.finalize();
-
-    Ok(&body_sha[..] == tree_sha)
+    let body_sha: [u8; 32] = sha256.finalize().into();
+    println!("CHECK {} =? {}({})", body_sha[0], tree_sha[0], tree_sha[tree_sha.len() - 1]);
+    Ok(body_sha == tree_sha)
 }
 
 fn is_hop_header(name: &str) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -541,7 +541,6 @@ fn validate_body(
     }
 
     let path = ["http_assets".into(), uri.path().into()];
-    println!("START {}", uri.path());
     let tree_sha = match tree.lookup_path(&path) {
         LookupResult::Found(v) => {
             v
@@ -562,7 +561,6 @@ fn validate_body(
     let mut sha256 = Sha256::new();
     sha256.update(response_body);
     let body_sha: [u8; 32] = sha256.finalize().into();
-    println!("CHECK {} =? {}({})", body_sha[0], tree_sha[0], tree_sha[tree_sha.len() - 1]);
     Ok(body_sha == tree_sha)
 }
 


### PR DESCRIPTION
That is missing part of body validation preprocessor.
Without this, the verification of certificates for the assets-canister does not work ().
Check [the service-worker realization](https://github.com/dfinity/ic/blob/0bc533b8930188cd9fe79ce9410d91bff5503add/typescript/service-worker/src/sw/http_request.ts#L182) for details