### PR TITLE
fix: prefix release tags with "rev-" to distinguish them from git revisions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,13 +149,12 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: binaries.tar.gz
           asset_name: binaries-${{ matrix.name }}.tar.gz
-          tag: ${{ env.SHA_SHORT }}
+          tag: rev-${{ env.SHA_SHORT }}
 
       - name: Upload deb
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: icx-proxy.deb
-          tag: ${{ env.SHA_SHORT }}
+          tag: rev-${{ env.SHA_SHORT }}
         if: contains(matrix.target, 'linux-musl')
-


### PR DESCRIPTION
This is an experiment to see if that fixes the bug of the 404
responses from https://github.com/dfinity/icx-proxy/releases.