### PR TITLE
feat: limit request body size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
@@ -961,6 +961,7 @@ dependencies = [
  "futures",
  "garcon",
  "hex",
+ "http-body",
  "hyper",
  "hyper-rustls",
  "hyper-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ flate2 = "1.0.0"
 futures = "0.3.21"
 garcon = { version = "0.2", features = ["async"] }
 hex = "0.4"
+http-body = "0.4.5"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.23", features = [ "webpki-roots" ] }
 hyper-tls = "0.5"


### PR DESCRIPTION
This change introduces the usage of `http_body::Limited` to ensure we don't allow incoming requests to exceed a certain size. We should consider using Tower going forward so that we can construct this using middlewares and not have all the logic live in one large function.