### PR TITLE
fix: use stream api instead of channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,12 +454,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -467,6 +483,17 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -503,9 +530,11 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -640,9 +669,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.17"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -766,6 +795,7 @@ dependencies = [
  "candid",
  "clap",
  "flate2",
+ "futures",
  "garcon",
  "hex",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ anyhow = "1"
 base64 = "0.13"
 candid = { version = "0.7", features = ["mute_warnings"] }
 clap = { version = "3", features = ["cargo", "derive"] }
-flate2 = "1.0.0"
+flate2 = "1"
+futures = "0.3"
 garcon = { version = "0.2", features = ["async"] }
 hex = "0.4"
 hyper = { version = "0.14", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,16 +428,16 @@ async fn forward_request(
                 body.chain(futures::stream::try_unfold(
                     (
                         logger.clone(),
-                        agent.clone(),
+                        agent,
                         callback.callback.0,
                         Some(callback.token),
                     ),
                     move |(logger, agent, callback, callback_token)| async move {
-                        let callback_token = if let Some(callback_token) = callback_token {
-                            callback_token
-                        } else {
-                            return Ok(None);
+                        let callback_token = match callback_token {
+                            Some(callback_token) => callback_token,
+                            None => return Ok(None),
                         };
+
                         let canister = HttpRequestCanister::create(&agent, callback.principal);
                         match canister
                             .http_request_stream_callback(&callback.method, callback_token)


### PR DESCRIPTION
Spawning a task has some slightly different async properties compared to the stream api, and in this case, we should prefer the stream api.

This allows us to buffer a preset amount and ties the cancellation of the downstream request more closely to the upstream request.