### PR TITLE
feat: Add metrics for validation

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,0 +1,94 @@
+use ic_utils::interfaces::http_request::HeaderField;
+use lazy_regex::regex_captures;
+
+const MAX_LOG_CERT_NAME_SIZE: usize = 100;
+const MAX_LOG_CERT_B64_SIZE: usize = 2000;
+
+pub struct HeadersData {
+    pub certificate: Option<Result<Vec<u8>, ()>>,
+    pub tree: Option<Result<Vec<u8>, ()>>,
+    pub encoding: Option<String>,
+}
+
+pub fn extract_headers_data(headers: &[HeaderField], logger: &slog::Logger) -> HeadersData {
+    let mut headers_data = HeadersData {
+        certificate: None,
+        tree: None,
+        encoding: None,
+    };
+
+    for HeaderField(name, value) in headers {
+        if name.eq_ignore_ascii_case("IC-CERTIFICATE") {
+            for field in value.split(',') {
+                if let Some((_, name, b64_value)) = regex_captures!("^(.*)=:(.*):$", field.trim()) {
+                    slog::trace!(
+                        logger,
+                        ">> certificate {:.l1$}: {:.l2$}",
+                        name,
+                        b64_value,
+                        l1 = MAX_LOG_CERT_NAME_SIZE,
+                        l2 = MAX_LOG_CERT_B64_SIZE
+                    );
+                    let bytes = decode_hash_tree(name, Some(b64_value.to_string()), logger);
+                    if name == "certificate" {
+                        headers_data.certificate = Some(match (headers_data.certificate, bytes) {
+                            (None, bytes) => bytes,
+                            (Some(Ok(certificate)), Ok(bytes)) => {
+                                slog::warn!(logger, "duplicate certificate field: {:?}", bytes);
+                                Ok(certificate)
+                            }
+                            (Some(Ok(certificate)), Err(_)) => {
+                                slog::warn!(
+                                    logger,
+                                    "duplicate certificate field (failed to decode)"
+                                );
+                                Ok(certificate)
+                            }
+                            (Some(Err(_)), bytes) => {
+                                slog::warn!(
+                                    logger,
+                                    "duplicate certificate field (failed to decode)"
+                                );
+                                bytes
+                            }
+                        });
+                    } else if name == "tree" {
+                        headers_data.tree = Some(match (headers_data.tree, bytes) {
+                            (None, bytes) => bytes,
+                            (Some(Ok(tree)), Ok(bytes)) => {
+                                slog::warn!(logger, "duplicate tree field: {:?}", bytes);
+                                Ok(tree)
+                            }
+                            (Some(Ok(tree)), Err(_)) => {
+                                slog::warn!(logger, "duplicate tree field (failed to decode)");
+                                Ok(tree)
+                            }
+                            (Some(Err(_)), bytes) => {
+                                slog::warn!(logger, "duplicate tree field (failed to decode)");
+                                bytes
+                            }
+                        });
+                    }
+                }
+            }
+        } else if name.eq_ignore_ascii_case("CONTENT-ENCODING") {
+            let enc = value.trim().to_string();
+            headers_data.encoding = Some(enc);
+        }
+    }
+
+    headers_data
+}
+
+fn decode_hash_tree(
+    name: &str,
+    value: Option<String>,
+    logger: &slog::Logger,
+) -> Result<Vec<u8>, ()> {
+    match value {
+        Some(tree) => base64::decode(tree).map_err(|e| {
+            slog::warn!(logger, "Unable to decode {} from base64: {}", name, e);
+        }),
+        _ => Err(()),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ mod validate;
 use crate::{
     config::dns_canister_config::DnsCanisterConfig,
     headers::{extract_headers_data, HeadersData},
-    validate::validate,
+    validate::{Validate, Validator},
 };
 
 type HttpResponseAny = HttpResponse<Token, HttpRequestStreamingCallbackAny>;
@@ -377,7 +377,9 @@ async fn forward_request(
 
         builder.body(body)?
     } else {
-        let body_valid = validate(
+        let validator = Validator::new();
+
+        let body_valid = validator.validate(
             &headers_data,
             &canister_id,
             &agent,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -36,7 +36,10 @@ impl<T: Validate> Validate for WithMetrics<T> {
             .0
             .validate(headers_data, canister_id, agent, uri, response_body, logger);
 
-        let status = if out.is_ok() { "ok" } else { "fail" };
+        let mut status = if out.is_ok() { "ok" } else { "fail" };
+        if cfg!(feature = "skip_body_verification") {
+            status = "skip";
+        }
 
         let labels = &[KeyValue::new("status", status)];
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,48 @@
+use opentelemetry::{
+    metrics::{Counter, Meter},
+    KeyValue,
+};
+
+use crate::validate::Validate;
+
+pub struct WithMetrics<T>(pub T, pub MetricParams);
+
+pub struct MetricParams {
+    pub counter: Counter<u64>,
+}
+
+impl MetricParams {
+    pub fn new(meter: &Meter, name: &str) -> Self {
+        Self {
+            counter: meter
+                .u64_counter(format!("{name}.total"))
+                .with_description(format!("Counts occurences of {name} calls"))
+                .init(),
+        }
+    }
+}
+
+impl<T: Validate> Validate for WithMetrics<T> {
+    fn validate(
+        &self,
+        headers_data: &crate::headers::HeadersData,
+        canister_id: &candid::Principal,
+        agent: &ic_agent::Agent,
+        uri: &hyper::Uri,
+        response_body: &[u8],
+        logger: slog::Logger,
+    ) -> Result<(), String> {
+        let out = self
+            .0
+            .validate(headers_data, canister_id, agent, uri, response_body, logger);
+
+        let status = if out.is_ok() { "ok" } else { "fail" };
+
+        let labels = &[KeyValue::new("status", status)];
+
+        let MetricParams { counter } = &self.1;
+        counter.add(1, labels);
+
+        out
+    }
+}

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -14,7 +14,7 @@ use crate::HeadersData;
 const MAX_CHUNK_SIZE_TO_DECOMPRESS: usize = 1024;
 const MAX_CHUNKS_TO_DECOMPRESS: u64 = 10_240;
 
-pub trait Validate {
+pub trait Validate: Sync + Send {
     fn validate(
         &self,
         headers_data: &HeadersData,
@@ -76,11 +76,11 @@ impl Validate for Validator {
             (None, None) => Ok(()),
         };
 
-        if body_valid.is_err() && !cfg!(feature = "skip_body_verification") {
-            return body_valid;
+        if cfg!(feature = "skip_body_verification") {
+            return Ok(());
         }
 
-        Ok(())
+        body_valid
     }
 }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,0 +1,168 @@
+use std::io::Read;
+
+use candid::Principal;
+use flate2::read::{DeflateDecoder, GzDecoder};
+use hyper::Uri;
+use ic_agent::{
+    hash_tree::LookupResult, ic_types::HashTree, lookup_value, Agent, AgentError, Certificate,
+};
+use sha2::{Digest, Sha256};
+
+use crate::HeadersData;
+
+// The limit of a buffer we should decompress ~10mb.
+const MAX_CHUNK_SIZE_TO_DECOMPRESS: usize = 1024;
+const MAX_CHUNKS_TO_DECOMPRESS: u64 = 10_240;
+
+struct Certificates<'a> {
+    certificate: &'a Vec<u8>,
+    tree: &'a Vec<u8>,
+}
+
+pub fn validate(
+    headers_data: &HeadersData,
+    canister_id: &Principal,
+    agent: &Agent,
+    uri: &Uri,
+    response_body: &[u8],
+    logger: slog::Logger,
+) -> Result<(), String> {
+    let body_sha = if let Some(body_sha) =
+        decode_body_to_sha256(response_body, headers_data.encoding.clone())
+    {
+        body_sha
+    } else {
+        return Err("Body could not be decoded".into());
+    };
+
+    let body_valid = match (
+        headers_data.certificate.as_ref(),
+        headers_data.tree.as_ref(),
+    ) {
+        (Some(Ok(certificate)), Some(Ok(tree))) => match validate_body(
+            Certificates { certificate, tree },
+            canister_id,
+            agent,
+            uri,
+            &body_sha,
+            logger.clone(),
+        ) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err("Body does not pass verification".to_string()),
+            Err(e) => Err(format!("Certificate validation failed: {}", e)),
+        },
+        (Some(_), _) | (_, Some(_)) => Err("Body does not pass verification".to_string()),
+
+        // TODO: Remove this (FOLLOW-483)
+        // Canisters don't have to provide certified variables
+        // This should change in the future, grandfathering in current implementations
+        (None, None) => Ok(()),
+    };
+
+    if body_valid.is_err() && !cfg!(feature = "skip_body_verification") {
+        return body_valid;
+    }
+
+    Ok(())
+}
+
+fn decode_body_to_sha256(body: &[u8], encoding: Option<String>) -> Option<[u8; 32]> {
+    let mut sha256 = Sha256::new();
+    let mut decoded = [0u8; MAX_CHUNK_SIZE_TO_DECOMPRESS];
+    match encoding.as_deref() {
+        Some("gzip") => {
+            let mut decoder = GzDecoder::new(body);
+            for _ in 0..MAX_CHUNKS_TO_DECOMPRESS {
+                let bytes = decoder.read(&mut decoded).ok()?;
+                if bytes == 0 {
+                    return Some(sha256.finalize().into());
+                }
+                sha256.update(&decoded[0..bytes]);
+            }
+            if decoder.bytes().next().is_some() {
+                return None;
+            }
+        }
+        Some("deflate") => {
+            let mut decoder = DeflateDecoder::new(body);
+            for _ in 0..MAX_CHUNKS_TO_DECOMPRESS {
+                let bytes = decoder.read(&mut decoded).ok()?;
+                if bytes == 0 {
+                    return Some(sha256.finalize().into());
+                }
+                sha256.update(&decoded[0..bytes]);
+            }
+            if decoder.bytes().next().is_some() {
+                return None;
+            }
+        }
+        _ => sha256.update(body),
+    };
+    Some(sha256.finalize().into())
+}
+
+fn validate_body(
+    certificates: Certificates,
+    canister_id: &Principal,
+    agent: &Agent,
+    uri: &Uri,
+    body_sha: &[u8; 32],
+    logger: slog::Logger,
+) -> anyhow::Result<bool> {
+    let cert: Certificate =
+        serde_cbor::from_slice(certificates.certificate).map_err(AgentError::InvalidCborData)?;
+    let tree: HashTree =
+        serde_cbor::from_slice(certificates.tree).map_err(AgentError::InvalidCborData)?;
+
+    if let Err(e) = agent.verify(&cert, *canister_id, false) {
+        slog::trace!(logger, ">> certificate failed verification: {}", e);
+        return Ok(false);
+    }
+
+    let certified_data_path = vec![
+        "canister".into(),
+        canister_id.into(),
+        "certified_data".into(),
+    ];
+    let witness = match lookup_value(&cert, certified_data_path) {
+        Ok(witness) => witness,
+        Err(e) => {
+            slog::trace!(
+                logger,
+                ">> Could not find certified data for this canister in the certificate: {}",
+                e
+            );
+            return Ok(false);
+        }
+    };
+    let digest = tree.digest();
+
+    if witness != digest {
+        slog::trace!(
+            logger,
+            ">> witness ({}) did not match digest ({})",
+            hex::encode(witness),
+            hex::encode(digest)
+        );
+
+        return Ok(false);
+    }
+
+    let path = ["http_assets".into(), uri.path().into()];
+    let tree_sha = match tree.lookup_path(&path) {
+        LookupResult::Found(v) => v,
+        _ => match tree.lookup_path(&["http_assets".into(), "/index.html".into()]) {
+            LookupResult::Found(v) => v,
+            _ => {
+                slog::trace!(
+                    logger,
+                    ">> Invalid Tree in the header. Does not contain path {:?}",
+                    path
+                );
+                return Ok(false);
+            }
+        },
+    };
+
+    Ok(body_sha == tree_sha)
+}

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -189,3 +189,40 @@ fn validate_body(
 
     Ok(body_sha == tree_sha)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use candid::Principal;
+    use hyper::Uri;
+    use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, Agent};
+    use slog::o;
+
+    use crate::{
+        headers::HeadersData,
+        validate::{Validate, Validator},
+    };
+
+    #[test]
+    fn validate_nop() {
+        let headers = HeadersData {
+            certificate: None,
+            encoding: None,
+            tree: None,
+        };
+
+        let canister_id = Principal::from_text("wwc2m-2qaaa-aaaac-qaaaa-cai").unwrap();
+        let transport = ReqwestHttpReplicaV2Transport::create("http://www.example.com").unwrap();
+        let agent = Agent::builder().with_transport(transport).build().unwrap();
+        let uri = Uri::from_str("http://www.example.com").unwrap();
+        let body = vec![];
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        let validator = Validator::new();
+
+        let out = validator.validate(&headers, &canister_id, &agent, &uri, &body, logger);
+
+        assert_eq!(out, Ok(()));
+    }
+}


### PR DESCRIPTION
This change creates a `Validate` trait and then uses it to wrap the existing validation logic.
We then wrap our `Validator` struct using `WithMetrics` to expose whether requests passed/failed/skipped validation.